### PR TITLE
Fix navigation link colors for better readability

### DIFF
--- a/src/components/GlobalSearchHeader.tsx
+++ b/src/components/GlobalSearchHeader.tsx
@@ -502,12 +502,12 @@ export default function GlobalSearchHeader() {
 
           {/* Right: Actions */}
           <nav className="flex items-center gap-3">
-            <Link to="/matches" className="text-ink-body hover:text-ink-head">Find a Match</Link>
-            <Link to="/classes" className="text-ink-body hover:text-ink-head">Classes</Link>
-            <Link to="/mentors" className="text-ink-body hover:text-ink-head">Mentors</Link>
-            <Link to="/challenges" className="text-ink-body hover:text-ink-head">Challenges</Link>
-            <Link to="/map" className="text-ink-body hover:text-ink-head">Map</Link>
-            <Link to="/donate" className="text-ink-body hover:text-ink-head">Donate</Link>
+            <Link to="/matches" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 font-medium">Find a Match</Link>
+            <Link to="/classes" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 font-medium">Classes</Link>
+            <Link to="/mentors" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 font-medium">Mentors</Link>
+            <Link to="/challenges" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 font-medium">Challenges</Link>
+            <Link to="/map" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 font-medium">Map</Link>
+            <Link to="/donate" className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 font-medium">Donate</Link>
 
             {/* Credit pill */}
             <CreditBalancePill

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -83,7 +83,7 @@ const HomePage = () => {
                 variants={fadeInUp}
               >
                 Trade Skills. Learn Anything.{' '}
-                <span className="text-primary">Without Spending a Dollar.</span>
+                <span className="text-gradient">Without Spending a Dollar.</span>
               </motion.h1>
               
               <motion.p 
@@ -285,7 +285,7 @@ const HomePage = () => {
                   style={{
                     '--active-bg': '#ffffff',
                     '--active-bg-dark': '#4b5563',
-                    '--active-color': '#2563eb'
+                    '--active-color': 'var(--ink-head)'
                   } as React.CSSProperties}
                 >
                   <Users className="h-4 w-4" />
@@ -297,7 +297,7 @@ const HomePage = () => {
                   style={{
                     '--active-bg': '#ffffff',
                     '--active-bg-dark': '#4b5563',
-                    '--active-color': '#2563eb'
+                    '--active-color': 'var(--ink-head)'
                   } as React.CSSProperties}
                 >
                   <BookOpen className="h-4 w-4" />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -118,7 +118,7 @@ const HomePage = () => {
                     Find a Match
                   </Link>
                 </Button>
-                <Button asChild variant="outline" size="lg" className="h-12 px-8 text-lg border-primary text-primary hover:bg-primary/5 !border-blue-600 !text-blue-600 !bg-white hover:!bg-blue-50">
+                <Button asChild variant="outline" size="lg" className="h-12 px-8 text-lg border-primary text-primary hover:bg-primary/5">
                   <Link to="/classes">
                     <BookOpen className="mr-2 h-5 w-5" />
                     Browse Courses
@@ -366,7 +366,7 @@ const HomePage = () => {
                 ))}
               </div>
               <div className="text-center mt-8">
-                <Button asChild variant="outline" size="lg" className="border-primary text-primary hover:bg-primary/5 !border-blue-600 !text-blue-600 !bg-white hover:!bg-blue-50">
+                <Button asChild variant="outline" size="lg" className="border-primary text-primary hover:bg-primary/5">
                   <Link to="/search">
                     View All People
                     <ArrowRight className="ml-2 h-5 w-5" />
@@ -505,7 +505,7 @@ const HomePage = () => {
           </div>
 
           <div className="text-center mt-8">
-            <Button asChild variant="outline" size="lg" className="border-primary text-primary hover:bg-primary/5 !border-blue-600 !text-blue-600 !bg-white hover:!bg-blue-50">
+            <Button asChild variant="outline" size="lg" className="border-primary text-primary hover:bg-primary/5">
               <Link to="/challenges">
                 View All Challenges
                 <ArrowRight className="ml-2 h-5 w-5" />
@@ -701,12 +701,7 @@ const HomePage = () => {
                 <Button
                   size="lg"
                   variant="outline"
-                  className="border-2 !border-blue-600 !text-blue-600 hover:!bg-blue-50 !bg-white"
-                  style={{
-                    borderColor: '#2563eb',
-                    color: '#2563eb',
-                    backgroundColor: 'white'
-                  }}
+                  className="border-2 border-primary text-primary hover:bg-primary/5"
                 >
                   <Crown className="mr-2 h-5 w-5" />
                   Upgrade to Pro


### PR DESCRIPTION
## Purpose

The user identified readability issues with blue-colored text elements, specifically noting that the "Find a match" button and other navigation links were difficult to read due to poor color contrast. The goal was to improve the visual accessibility and readability of these UI elements.

## Code changes

- **Navigation header**: Replaced custom ink color classes with standard gray color scheme (`text-gray-700` with dark mode support) for all navigation links in `GlobalSearchHeader.tsx`
- **Homepage buttons**: Removed hardcoded blue color overrides (`!border-blue-600`, `!text-blue-600`) from outline buttons and reverted to semantic primary color variables
- **Tab components**: Updated active color CSS custom properties to use semantic ink color variables instead of hardcoded blue values
- **Gradient text**: Changed primary color span to use gradient text class for better visual hierarchy
- **Consistent styling**: Standardized button styling across the homepage to use design system colors rather than hardcoded values

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cb5df7fa249a4c40934884e6c7ddf044/zen-home)

👀 [Preview Link](https://cb5df7fa249a4c40934884e6c7ddf044-zen-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cb5df7fa249a4c40934884e6c7ddf044</projectId>-->
<!--<branchName>zen-home</branchName>-->